### PR TITLE
Make livenessprobe configurable

### DIFF
--- a/charts/ecr-exporter/README.md
+++ b/charts/ecr-exporter/README.md
@@ -49,3 +49,16 @@ helm install ecr-exporter aws-exporters/ecr-exporter
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
+| livenessProbe.httpGet.path | string | `"/metrics"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.initialDelaySecond | int | `30` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5

--- a/charts/ecr-exporter/README.md
+++ b/charts/ecr-exporter/README.md
@@ -55,10 +55,3 @@ helm install ecr-exporter aws-exporters/ecr-exporter
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
 
-livenessProbe:
-  httpGet:
-    path: /metrics
-    port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 5

--- a/charts/ecr-exporter/templates/deployment.yaml
+++ b/charts/ecr-exporter/templates/deployment.yaml
@@ -40,11 +40,7 @@ spec:
               containerPort: 9000
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /metrics
-              port: http
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /metrics

--- a/charts/ecr-exporter/values.yaml
+++ b/charts/ecr-exporter/values.yaml
@@ -60,3 +60,11 @@ env: []
   #   value: "112233445566"
   # - name: CACHE_REFRESH_INTERVAL
   #   value: "3600"
+
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5


### PR DESCRIPTION
Our ECR is too big, so the livenessProbe failed before the server was ready. I had to put in a livenessProbe initial delay to make it work for us :) 